### PR TITLE
Add fiddler wrapper to inotify.  Only ruby2.0

### DIFF
--- a/lib/change_monitors/inotify.rb
+++ b/lib/change_monitors/inotify.rb
@@ -1,0 +1,11 @@
+require 'fiddle'
+require 'fiddle/import'
+
+module LibNotify
+  extend Fiddle::Importer
+  #TODO: do this in a distro independent way
+  dlload '/lib/x86_64-linux-gnu/libc.so.6'
+  extern 'int inotify_init()'
+  extern 'int inotify_add_watch(int, const char*, unsigned int)' #fd, pathname, mask
+  extern 'int inotify_rm_watch(int, int)' # fd, wd
+end


### PR DESCRIPTION
TODO:

Use 1.9 compatible syntax.
Find libc in a distro/arch independent way.
Windows/OSX support.
