### PR TITLE
Convert lib/conf.rb to use XDG specification.

### DIFF
--- a/lib/conf.rb
+++ b/lib/conf.rb
@@ -8,8 +8,11 @@ require 'fileutils'
 module Conf
   # Where should we store information about shares and peers?
   def self.data_dir filename=nil
-    # FIXME Is this the proper default directory?
-    path = ENV['CLEARSKIES_DIR'] || "#{ENV['HOME']}/.local/share/clearskies"
+    # Follow XDG specifications for storing application specific data
+    # http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    xdg_data_home = ENV['XDG_DATA_HOME'] || "#{ENV['$HOME']}/.local/share"
+    path = ENV['CLEARSKIES_DIR'] || "#{xdg_data_home}/clearskies"
+
     FileUtils.mkdir_p path
     path = "#{path}/#{filename}" if filename
     path

--- a/protocol/control.md
+++ b/protocol/control.md
@@ -10,7 +10,7 @@ This protocol is incomplete.  This draft covers version 1 of the protocol, but
 more message types will be added without bumping the version.
 
 By default, the daemon listens for connections on the unix socket residing at
-$HOME/.local/share/clearskies/control.
+$XDG_DATA_HOME/clearskies/control.
 
 
 Wire protocol


### PR DESCRIPTION
Conform to XDG specification standards for applicationfiles.  By default it will put files in the $XDG_DATA_HOME/clearskies directory.

In the event $XDG_DATA_HOME is not set it is defaulted to $HOME/.local/share per the specification.

See: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
