### PR TITLE
Change message header to be fixed width or remove it

### DIFF
--- a/protocol/core.md
+++ b/protocol/core.md
@@ -206,7 +206,8 @@ prefix.
 Each of these types will be explained in turn.
 
 For all message types the length of the JSON object is added after the prefix,
-using ASCII characters.  The maximum size for the JSON body is 16777216 bytes.
+ in hexedecimal, using ASCII characters.  The size is padded with zeros and 
+ will always be 6 characters.  The maximum size for the JSON body is 16777216 bytes.
 
 The JSON body must start with a "{" character.  That is to say, it is not valid
 to have an array, string, or other non-object as the body.
@@ -219,7 +220,7 @@ The object will have a "type" member, which will identify the type of message.
 For example:
 
 ```
-m82{
+m000052{
   "type": "foo",
   "message": "Basic example message",
   "declaration": "For great justice"


### PR DESCRIPTION
I propose that we update the message header to be a fixed width or remove it entirely.

If the header exists to simplify implementations, it should be a fixed width.  This can be achieved by padding the size with zeros.  The proposed commit makes the header exactly 7 characters for any message by representing the size in hexadecimal and padding it.

The JSON message size is already capped, so I can see no other reason for including the header upfront other than implementation convenience?

The rest of the core spec needs to be updated to be consistent with any change.
