### PR TITLE
Make it clear that ClearSkies is not just file sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 ClearSkies
 ==========
 
-ClearSkies is a sync program similar to DropBox, except it does not require a
-monthly fee.  Instead, you set up shares between two or more computers and the
-sharing happens amongst them directly.
+ClearSkies is a friend-to-friend protocol.  ClearSkies is inspired by BitTorrent
+Sync, but it has an open protocol that can be audited for security.  The
+protocol is also layered in such a way that other applications can take
+advantage of it for purposes other than file sync.
 
-ClearSkies is inspired by BitTorrent Sync, but it has an open protocol that can
-be audited for security.
-
-The protocol is layered in such a way that other applications can take advantage
-of it for purposes other than file sync.
+ClearSkiesSync is a sync program similar to DropBox, except it does not
+require a monthly fee.  Instead, you set up shares between two or more
+computers and the sharing happens amongst them directly.
 
 
 The Protocol


### PR DESCRIPTION
Make is extremely clear that while file sync is one really useful application of clearskies, it is now written in such a way that any friend-to-friend application is supported by the protocol.
